### PR TITLE
feat: allow specifying multiple transforms

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,7 +16,7 @@ program
   .usage('[global options] <file-paths>...')
   .option(
     '-t, --transform <value>',
-    'The transform to run, will prompt for a transform if not provided and no module is passed',
+    'The transform(s) to run, will prompt for a transform if not provided and no module is passed\nTo provide multiple transforms, separate them with commas (e.g. "-t t1,t2,t3")',
   )
   .option(
     '--packages <value>',

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -23,7 +23,11 @@ export default async function main(paths: string[], flags: Flags) {
   }
 
   if (flags.transform) {
-    transforms.push(flags.transform);
+    if (flags.transform.includes(',')) {
+      flags.transform.split(',').forEach(t => transforms.push(t.trim()));
+    } else {
+      transforms.push(flags.transform);
+    }
   }
 
   const packageManager = new PluginManager();


### PR DESCRIPTION
maybe would be nicer if the interface would be `-t t1 -t t2 -t t3`
instead of current `-t t1,t2,t3` (you could separate into multiple lines
and keep it cleaner), but don't know how to do that so this works just fine.

---

upstream PR: https://github.com/CodeshiftCommunity/CodeshiftCommunity/pull/66
