### PR TITLE
fix: add missing jsx attribute to correct component instead of whole subtree

### DIFF
--- a/packages/reusable-transforms/src/add-missing-jsx-attribute/add-missing-jsx-attribute.ts
+++ b/packages/reusable-transforms/src/add-missing-jsx-attribute/add-missing-jsx-attribute.ts
@@ -75,14 +75,12 @@ export const addMissingJsxProp: Transformer<ConfigToAddMissingJsxProp> = (
         return;
     }
 
-    src.find(j.JSXElement, {
-        openingElement: {
-            name: {
-                name: config.exportedAs,
-            },
+    src.find(j.JSXOpeningElement, {
+        name: {
+            name: config.exportedAs,
         },
     })
-        .find(j.JSXOpeningElement)
+        //
         .forEach((path: ASTPath<JSXOpeningElement>): void => {
             const { node } = path;
 


### PR DESCRIPTION
the issue here was that if you find all `JSXElement`s, and then find all `JSXOpeningElements`, it won't just find the very first opening elements - it'll find __all__ of them, no matter how deep in the subtree.

with the patch, we now do the `.find`ing of the opening element directly, together with the filtering object, thus it works correctly now.

the first find of JSXElement wasn't even necessary - when i coded it i think i hadn't used jscodeshift enough to realise it quickly. good that @martinrajdl ran the codemods & caught this:D

- [ ] check other places & confirm they don't have the same issue